### PR TITLE
Fix for gasless meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 15-06-2021
+### Updated
+- Improved logging
+- Allow electricity only meters 
+
 ## [1.4.0] - 02-06-2021
 ### Added
 - PING/PONG error condition

--- a/SensateIoT.SmartEnergy.Dsmr.WebClient.Service/Properties/AssemblyInfo.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.WebClient.Service/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.4.1.0")]
+[assembly: AssemblyFileVersion("1.4.1.0")]


### PR DESCRIPTION
Allow using meters/devices without gas data or registered gas sensor. For these meters only the electrical data is parsed and stored as usual.